### PR TITLE
Add stats page for flashcard progress

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <button id="shuffleBtn">Shuffle</button>
       <button id="resetBtn">Reset stats</button>
       <button id="editDeckBtn">Deck JSON</button>
+      <a href="/stats" class="button-link">Stats</a>
     </div>
   </header>
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,12 @@ var appJS string
 //go:embed styles.css
 var stylesCSS string
 
+//go:embed stats.html
+var statsHTML string
+
+//go:embed stats.js
+var statsJS string
+
 func main() {
 	mux := http.NewServeMux()
 
@@ -35,6 +41,18 @@ func main() {
 	mux.HandleFunc("/styles.css", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/css; charset=utf-8")
 		fmt.Fprint(w, stylesCSS)
+	})
+
+	// Serve stats.html
+	mux.HandleFunc("/stats", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, statsHTML)
+	})
+
+	// Serve stats.js
+	mux.HandleFunc("/stats.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		fmt.Fprint(w, statsJS)
 	})
 
 	addr := ":8080"

--- a/stats.html
+++ b/stats.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stats - Shavian Flashcards</title>
+  <link rel="stylesheet" href="/styles.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <header class="bar">
+    <h1>Stats</h1>
+    <div class="actions"><a href="/" class="button-link">Cards</a></div>
+  </header>
+
+  <main class="stats-page">
+    <div class="stats-cards">
+      <div class="stat"><div id="totalSessions" class="num">0</div><div class="lbl">Sessions</div></div>
+      <div class="stat"><div id="totalCorrect" class="num">0</div><div class="lbl">Correct</div></div>
+      <div class="stat"><div id="totalWrong" class="num">0</div><div class="lbl">Wrong</div></div>
+      <div class="stat"><div id="overallAcc" class="num">0%</div><div class="lbl">Accuracy</div></div>
+    </div>
+
+    <h2>Per-card performance</h2>
+    <div class="chart-wrap">
+      <canvas id="perCardChart"></canvas>
+    </div>
+  </main>
+
+  <footer class="foot">Built with Go + vanilla JS. Data lives in your browser (localStorage).</footer>
+
+  <script src="/stats.js"></script>
+</body>
+</html>

--- a/stats.js
+++ b/stats.js
@@ -1,0 +1,34 @@
+(() => {
+  const STORAGE_PREFIX = 'shavian_go_v1_';
+  const stats = JSON.parse(localStorage.getItem(STORAGE_PREFIX + 'stats') || '{}');
+  const deck = JSON.parse(localStorage.getItem(STORAGE_PREFIX + 'deck') || '[]');
+
+  document.getElementById('totalSessions').textContent = stats.sessions || 1;
+  document.getElementById('totalCorrect').textContent = stats.totalCorrect || 0;
+  document.getElementById('totalWrong').textContent = stats.totalWrong || 0;
+  const total = (stats.totalCorrect || 0) + (stats.totalWrong || 0);
+  document.getElementById('overallAcc').textContent = total ? Math.round((stats.totalCorrect || 0) / total * 100) + '%' : '0%';
+
+  const labels = deck.map(d => d.glyph);
+  const correct = deck.map(d => (stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id].correct : 0));
+  const wrong = deck.map(d => (stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id].wrong : 0));
+
+  const ctx = document.getElementById('perCardChart').getContext('2d');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        { label: 'Correct', data: correct, backgroundColor: 'rgba(16,185,129,0.7)' },
+        { label: 'Wrong', data: wrong, backgroundColor: 'rgba(239,68,68,0.7)' }
+      ]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        x: { stacked: true },
+        y: { stacked: true, beginAtZero: true }
+      }
+    }
+  });
+})();

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,7 @@ body{ margin:0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Noto Sa
 button{ padding:10px 14px; border-radius:12px; border:1px solid var(--line); background:#fff; cursor:pointer; }
 button.correct{ background: #10b981; color:#fff; border-color:#10b981; }
 button.wrong{ background: #fecaca; border-color:#fecaca; }
+ a.button-link{ padding:10px 14px; border-radius:12px; border:1px solid var(--line); background:#fff; text-decoration:none; color:var(--ink); display:inline-block; }
 .progress{ height:8px; background:#e5e7eb; border-radius:9999px; overflow:hidden; margin:8px 0 14px; }
 #progressInner{ height:100%; background:#10b981; width:0%; }
 .stats{ background:#fff; border:1px solid var(--line); border-radius:16px; padding:16px; box-shadow: 0 1px 2px rgba(0,0,0,.05); }
@@ -36,4 +37,6 @@ dialog form{ padding:16px; }
 #deckTextarea{ width:100%; height:340px; font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; padding:10px; border:1px solid var(--line); border-radius:12px; }
 .dlg-actions{ display:flex; gap:8px; justify-content:flex-end; margin-top:8px; }
 button.primary{ background:#0ea5e9; color:#fff; border-color:#0ea5e9; }
+.stats-page{ max-width:900px; margin:0 auto; padding:16px; }
+.chart-wrap{ max-width:100%; }
 @media (max-width: 900px){ .grid{ grid-template-columns: 1fr; } #cardFront{ font-size:72px; } }


### PR DESCRIPTION
## Summary
- add dedicated stats page with chart.js visualizing per-card performance
- expose new stats routes and assets in Go server
- link to stats page from main interface and add styles

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897da18185483329ce17213257a4c11