### PR TITLE
Add time-based progress chart

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,6 +62,7 @@
     totalWrong: 0,
     perCard: {},
     sessions: 1,
+    attempts: [],
   };
 
   function persist() {
@@ -124,6 +125,7 @@
     if (result === 'correct') { pc.correct++; stats.totalCorrect++; }
     else { pc.wrong++; stats.totalWrong++; }
     stats.perCard[id] = pc;
+    (stats.attempts || (stats.attempts = [])).push({ t: Date.now(), result });
     requeue(result);
     render();
   }
@@ -133,7 +135,7 @@
     idx = 0; flipped = false; render();
   });
   el('resetBtn').addEventListener('click', () => {
-    stats = { totalCorrect: 0, totalWrong: 0, perCard: {}, sessions: (stats.sessions||0)+1 };
+    stats = { totalCorrect: 0, totalWrong: 0, perCard: {}, sessions: (stats.sessions||0)+1, attempts: [] };
     queue = shuffle(deck.map(d => d.id));
     idx = 0; flipped = false; render();
   });

--- a/stats.html
+++ b/stats.html
@@ -6,6 +6,7 @@
   <title>Stats - Shavian Flashcards</title>
   <link rel="stylesheet" href="/styles.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
 </head>
 <body>
   <header class="bar">
@@ -19,6 +20,11 @@
       <div class="stat"><div id="totalCorrect" class="num">0</div><div class="lbl">Correct</div></div>
       <div class="stat"><div id="totalWrong" class="num">0</div><div class="lbl">Wrong</div></div>
       <div class="stat"><div id="overallAcc" class="num">0%</div><div class="lbl">Accuracy</div></div>
+    </div>
+
+    <h2>Learning progress over time</h2>
+    <div class="chart-wrap">
+      <canvas id="progressChart"></canvas>
     </div>
 
     <h2>Per-card performance</h2>

--- a/stats.js
+++ b/stats.js
@@ -9,9 +9,30 @@
   const total = (stats.totalCorrect || 0) + (stats.totalWrong || 0);
   document.getElementById('overallAcc').textContent = total ? Math.round((stats.totalCorrect || 0) / total * 100) + '%' : '0%';
 
+  const attempts = stats.attempts || [];
+  let corr = 0, wrongCnt = 0;
+  const progressPoints = attempts.map(a => {
+    if (a.result === 'correct') corr++; else wrongCnt++;
+    const pct = (corr + wrongCnt) ? corr / (corr + wrongCnt) * 100 : 0;
+    return { x: new Date(a.t), y: pct };
+  });
+
   const labels = deck.map(d => d.glyph);
   const correct = deck.map(d => (stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id].correct : 0));
   const wrong = deck.map(d => (stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id].wrong : 0));
+
+  const progCtx = document.getElementById('progressChart').getContext('2d');
+  new Chart(progCtx, {
+    type: 'line',
+    data: { datasets: [{ label: '% Learned', data: progressPoints, borderColor: 'rgba(59,130,246,0.8)', fill: false }] },
+    options: {
+      responsive: true,
+      scales: {
+        x: { type: 'time' },
+        y: { beginAtZero: true, max: 100 }
+      }
+    }
+  });
 
   const ctx = document.getElementById('perCardChart').getContext('2d');
   new Chart(ctx, {


### PR DESCRIPTION
## Summary
- Track each card attempt with a timestamp in local storage
- Display learning progress over time with a new Chart.js line chart
- Reset stats now clears attempt history

## Testing
- `npm test` *(fails: Could not read package.json)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897dcfbb830833297adf751a903fdd1