### PR TITLE
Enhance stats visualizations with ordering and prediction

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -9,22 +9,63 @@
   const total = (stats.totalCorrect || 0) + (stats.totalWrong || 0);
   document.getElementById('overallAcc').textContent = total ? Math.round((stats.totalCorrect || 0) / total * 100) + '%' : '0%';
 
+  const clamp = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
+
   const attempts = stats.attempts || [];
-  let corr = 0, wrongCnt = 0;
-  const progressPoints = attempts.map(a => {
-    if (a.result === 'correct') corr++; else wrongCnt++;
-    const pct = (corr + wrongCnt) ? corr / (corr + wrongCnt) * 100 : 0;
-    return { x: new Date(a.t), y: pct };
+  const alpha = 0.3; // weight newer data more heavily
+  let ema = 0;
+  const progressPoints = attempts.map((a, i) => {
+    const val = a.result === 'correct' ? 1 : 0;
+    ema = i === 0 ? val : alpha * val + (1 - alpha) * ema;
+    return { x: new Date(a.t), y: ema * 100 };
   });
 
-  const labels = deck.map(d => d.glyph);
-  const correct = deck.map(d => (stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id].correct : 0));
-  const wrong = deck.map(d => (stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id].wrong : 0));
+  function regression(points) {
+    const n = points.length;
+    if (n === 0) return { m: 0, b: 0 };
+    let sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
+    points.forEach((p, i) => {
+      sumX += i; sumY += p.y; sumXY += i * p.y; sumXX += i * i;
+    });
+    const denom = n * sumXX - sumX * sumX;
+    const m = denom ? (n * sumXY - sumX * sumY) / denom : 0;
+    const b = (sumY - m * sumX) / n;
+    return { m, b };
+  }
+
+  const trend = regression(progressPoints);
+  const futurePoints = [];
+  if (progressPoints.length) {
+    const lastTime = attempts.length ? attempts[attempts.length - 1].t : Date.now();
+    const avgInterval = attempts.length > 1 ?
+      (attempts[attempts.length - 1].t - attempts[0].t) / (attempts.length - 1) : 60000;
+    const lastIdx = progressPoints.length - 1;
+    for (let i = 1; i <= 10; i++) {
+      const idx = lastIdx + i;
+      const time = new Date(lastTime + avgInterval * i);
+      const y = clamp(trend.m * idx + trend.b, 0, 100);
+      futurePoints.push({ x: time, y });
+    }
+  }
+
+  const perCardStats = deck.map(d => {
+    const pc = stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id] : { correct: 0, wrong: 0 };
+    return { glyph: d.glyph, correct: pc.correct, wrong: pc.wrong, diff: pc.correct - pc.wrong };
+  }).sort((a, b) => b.diff - a.diff);
+
+  const labels = perCardStats.map(p => p.glyph);
+  const correct = perCardStats.map(p => p.correct);
+  const wrong = perCardStats.map(p => p.wrong);
 
   const progCtx = document.getElementById('progressChart').getContext('2d');
   new Chart(progCtx, {
     type: 'line',
-    data: { datasets: [{ label: '% Learned', data: progressPoints, borderColor: 'rgba(59,130,246,0.8)', fill: false }] },
+    data: {
+      datasets: [
+        { label: '% Learned', data: progressPoints, borderColor: 'rgba(59,130,246,0.8)', fill: false },
+        { label: 'Trend', data: futurePoints, borderColor: 'rgba(16,185,129,0.6)', borderDash: [5,5], fill: false }
+      ]
+    },
     options: {
       responsive: true,
       scales: {


### PR DESCRIPTION
## Summary
- Sort per-card stats from most correct to most wrong
- Weight progress chart toward recent answers using exponential average
- Add trend prediction line projecting future learning

## Testing
- `npm test` *(fails: Could not read package.json)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897e165eb488332998392fc463543e2