### PR TITLE
Add cheat sheet page and ensure per-card stats are recorded

### DIFF
--- a/cheatsheet.html
+++ b/cheatsheet.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cheat Sheet - Shavian Flashcards</title>
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <header class="bar">
+    <h1>Cheat Sheet</h1>
+    <div class="actions">
+      <a href="/" class="button-link">Cards</a>
+      <a href="/stats" class="button-link">Stats</a>
+    </div>
+  </header>
+
+  <main class="stats-page">
+    <h2>Shavian Letters</h2>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Letter</th><th>Name</th><th>IPA</th></tr></thead>
+        <tbody id="cheatBody"></tbody>
+      </table>
+    </div>
+
+    <h2>Try spelling</h2>
+    <input id="spellInput" type="text" readonly />
+    <div id="keyboard" class="keyboard"></div>
+    <div class="controls">
+      <button id="backspaceBtn" type="button">Backspace</button>
+      <button id="clearBtn" type="button">Clear</button>
+    </div>
+  </main>
+
+  <footer class="foot">Built with Go + vanilla JS. Data lives in your browser (localStorage).</footer>
+
+  <script src="/cheatsheet.js"></script>
+</body>
+</html>

--- a/cheatsheet.js
+++ b/cheatsheet.js
@@ -1,0 +1,23 @@
+(() => {
+  const STORAGE_PREFIX = 'shavian_go_v1_';
+  const deck = JSON.parse(localStorage.getItem(STORAGE_PREFIX + 'deck') || '[]');
+
+  const body = document.getElementById('cheatBody');
+  deck.forEach(d => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="glyph">${d.glyph}</td><td>${d.name}</td><td>${d.ipa || ''}</td>`;
+    body.appendChild(tr);
+  });
+
+  const input = document.getElementById('spellInput');
+  const keyboard = document.getElementById('keyboard');
+  deck.forEach(d => {
+    const btn = document.createElement('button');
+    btn.textContent = d.glyph;
+    btn.addEventListener('click', () => { input.value += d.glyph; });
+    keyboard.appendChild(btn);
+  });
+
+  document.getElementById('clearBtn').addEventListener('click', () => { input.value = ''; });
+  document.getElementById('backspaceBtn').addEventListener('click', () => { input.value = input.value.slice(0, -1); });
+})();

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       <button id="shuffleBtn">Shuffle</button>
       <button id="resetBtn">Reset stats</button>
       <button id="editDeckBtn">Deck JSON</button>
+      <a href="/cheatsheet" class="button-link">Cheat sheet</a>
       <a href="/stats" class="button-link">Stats</a>
     </div>
   </header>

--- a/main.go
+++ b/main.go
@@ -22,6 +22,12 @@ var statsHTML string
 //go:embed stats.js
 var statsJS string
 
+//go:embed cheatsheet.html
+var cheatHTML string
+
+//go:embed cheatsheet.js
+var cheatJS string
+
 func main() {
 	mux := http.NewServeMux()
 
@@ -53,6 +59,18 @@ func main() {
 	mux.HandleFunc("/stats.js", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
 		fmt.Fprint(w, statsJS)
+	})
+
+	// Serve cheatsheet.html
+	mux.HandleFunc("/cheatsheet", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprint(w, cheatHTML)
+	})
+
+	// Serve cheatsheet.js
+	mux.HandleFunc("/cheatsheet.js", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		fmt.Fprint(w, cheatJS)
 	})
 
 	addr := ":8080"

--- a/stats.html
+++ b/stats.html
@@ -11,7 +11,7 @@
 <body>
   <header class="bar">
     <h1>Stats</h1>
-    <div class="actions"><a href="/" class="button-link">Cards</a></div>
+    <div class="actions"><a href="/" class="button-link">Cards</a><a href="/cheatsheet" class="button-link">Cheat sheet</a></div>
   </header>
 
   <main class="stats-page">

--- a/stats.js
+++ b/stats.js
@@ -49,8 +49,10 @@
   }
 
   const perCardStats = deck.map(d => {
-    const pc = stats.perCard && stats.perCard[d.id] ? stats.perCard[d.id] : { correct: 0, wrong: 0 };
-    return { glyph: d.glyph, correct: pc.correct, wrong: pc.wrong, diff: pc.correct - pc.wrong };
+    const pcRaw = (stats.perCard && stats.perCard[d.id]) || {};
+    const correct = pcRaw.correct || 0;
+    const wrong = pcRaw.wrong || 0;
+    return { glyph: d.glyph, correct, wrong, diff: correct - wrong };
   }).sort((a, b) => b.diff - a.diff);
 
   const labels = perCardStats.map(p => p.glyph);

--- a/styles.css
+++ b/styles.css
@@ -40,3 +40,7 @@ button.primary{ background:#0ea5e9; color:#fff; border-color:#0ea5e9; }
 .stats-page{ max-width:900px; margin:0 auto; padding:16px; }
 .chart-wrap{ max-width:100%; }
 @media (max-width: 900px){ .grid{ grid-template-columns: 1fr; } #cardFront{ font-size:72px; } }
+
+.keyboard{ display:flex; flex-wrap:wrap; gap:4px; margin-top:8px; }
+.keyboard button{ width:40px; height:40px; font-size:24px; padding:0; }
+#spellInput{ width:100%; margin-top:8px; font-size:24px; padding:8px; border:1px solid var(--line); border-radius:12px; }


### PR DESCRIPTION
## Summary
- Ensure per-card stats default missing values to zero so every letter appears in performance graphs
- Add a cheat sheet page with an on-screen keyboard for practicing spelling
- Link the new page in navigation and serve it from the Go server

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897e3cd1b48833293022caae02c9301