### PR TITLE
Use Fourier forecast for progress trend

### DIFF
--- a/stats.js
+++ b/stats.js
@@ -20,38 +20,64 @@
     return { x: new Date(a.t), y: ema * 100 };
   });
 
-  function regression(points) {
+  function fourierForecast(points, steps) {
     const n = points.length;
-    if (n === 0) return { m: 0, b: 0, moe: 0 };
-    let sumX = 0, sumY = 0, sumXY = 0, sumXX = 0;
-    points.forEach((p, i) => {
-      sumX += i; sumY += p.y; sumXY += i * p.y; sumXX += i * i;
-    });
-    const denom = n * sumXX - sumX * sumX;
-    const m = denom ? (n * sumXY - sumX * sumY) / denom : 0;
-    const b = (sumY - m * sumX) / n;
-    let sse = 0;
-    points.forEach((p, i) => { const yHat = m * i + b; sse += (p.y - yHat) * (p.y - yHat); });
-    const stderr = Math.sqrt(sse / Math.max(n - 2, 1));
-    const moe = 1.96 * stderr;
-    return { m, b, moe };
+    if (n === 0) return { forecast: [], moe: 0 };
+    const y = points.map(p => p.y);
+    const kMax = Math.min(5, Math.floor(n / 2));
+    const twoPiOverN = 2 * Math.PI / n;
+    const a = new Array(kMax + 1).fill(0);
+    const b = new Array(kMax + 1).fill(0);
+    for (let k = 0; k <= kMax; k++) {
+      let sumA = 0, sumB = 0;
+      for (let t = 0; t < n; t++) {
+        const angle = twoPiOverN * k * t;
+        sumA += y[t] * Math.cos(angle);
+        sumB += y[t] * Math.sin(angle);
+      }
+      a[k] = (2 / n) * sumA;
+      b[k] = (2 / n) * sumB;
+    }
+    a[0] /= 2;
+
+    const fit = [];
+    for (let t = 0; t < n; t++) {
+      let val = a[0];
+      for (let k = 1; k <= kMax; k++) {
+        const angle = twoPiOverN * k * t;
+        val += a[k] * Math.cos(angle) + b[k] * Math.sin(angle);
+      }
+      fit.push(val);
+    }
+    const rmse = Math.sqrt(fit.reduce((acc, val, i) => acc + (y[i] - val) * (y[i] - val), 0) / n);
+    const moe = 1.96 * rmse;
+
+    const forecast = [];
+    for (let i = 1; i <= steps; i++) {
+      const t = n + i - 1;
+      let val = a[0];
+      for (let k = 1; k <= kMax; k++) {
+        const angle = twoPiOverN * k * t;
+        val += a[k] * Math.cos(angle) + b[k] * Math.sin(angle);
+      }
+      forecast.push(val);
+    }
+    return { forecast, moe };
   }
 
-  const trend = regression(progressPoints);
+  const trend = fourierForecast(progressPoints, 10);
   const futurePoints = [], futureUpper = [], futureLower = [];
   if (progressPoints.length) {
     const lastTime = attempts.length ? attempts[attempts.length - 1].t : Date.now();
     const avgInterval = attempts.length > 1 ?
       (attempts[attempts.length - 1].t - attempts[0].t) / (attempts.length - 1) : 60000;
-    const lastIdx = progressPoints.length - 1;
-    for (let i = 1; i <= 10; i++) {
-      const idx = lastIdx + i;
-      const time = new Date(lastTime + avgInterval * i);
-      const y = clamp(trend.m * idx + trend.b, 0, 100);
+    trend.forecast.forEach((val, i) => {
+      const time = new Date(lastTime + avgInterval * (i + 1));
+      const y = clamp(val, 0, 100);
       futurePoints.push({ x: time, y });
       futureUpper.push({ x: time, y: clamp(y + trend.moe, 0, 100) });
       futureLower.push({ x: time, y: clamp(y - trend.moe, 0, 100) });
-    }
+    });
   }
 
   const perCardStats = deck.map(d => {
@@ -71,9 +97,9 @@
     data: {
       datasets: [
         { label: '% Learned', data: progressPoints, borderColor: 'rgba(16,185,129,0.8)', fill: false },
-        { label: `Trend (±${trend.moe.toFixed(1)}%)`, data: futurePoints, borderColor: 'rgba(59,130,246,0.8)', fill: false },
-        { label: 'Trend Upper', data: futureUpper, borderColor: 'rgba(59,130,246,0.3)', borderDash: [5,5], fill: false, pointRadius: 0 },
-        { label: 'Trend Lower', data: futureLower, borderColor: 'rgba(59,130,246,0.3)', borderDash: [5,5], fill: false, pointRadius: 0 }
+        { label: `Fourier Forecast (±${trend.moe.toFixed(1)}%)`, data: futurePoints, borderColor: 'rgba(59,130,246,0.8)', fill: false },
+        { label: 'Forecast Upper', data: futureUpper, borderColor: 'rgba(59,130,246,0.3)', borderDash: [5,5], fill: false, pointRadius: 0 },
+        { label: 'Forecast Lower', data: futureLower, borderColor: 'rgba(59,130,246,0.3)', borderDash: [5,5], fill: false, pointRadius: 0 }
       ]
     },
     options: {


### PR DESCRIPTION
## Summary
- Replace linear regression with Fourier series based forecast to project learning progress
- Show forecast line with upper/lower bounds in stats chart

## Testing
- `node --check stats.js`
- `go build ./...` *(fails: command hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6897eccd92248332b3322a5baebcbddd