### PR TITLE
Connect forecast lines to progress data

### DIFF
--- a/app.js
+++ b/app.js
@@ -184,8 +184,8 @@
       });
       const lastPoint = progressPoints[progressPoints.length - 1];
       futurePoints.unshift(lastPoint);
-      futureUpper.unshift({ x: lastPoint.x, y: clamp(lastPoint.y + trend.moe, 0, 100) });
-      futureLower.unshift({ x: lastPoint.x, y: clamp(lastPoint.y - trend.moe, 0, 100) });
+      futureUpper.unshift({ x: lastPoint.x, y: lastPoint.y });
+      futureLower.unshift({ x: lastPoint.x, y: lastPoint.y });
     }
     const learned = progressPoints.length ? progressPoints[progressPoints.length - 1].y : 0;
     const predicted = futurePoints.length > 1 ? futurePoints[1].y : learned;

--- a/stats.js
+++ b/stats.js
@@ -80,8 +80,8 @@
     });
     const lastPoint = progressPoints[progressPoints.length - 1];
     futurePoints.unshift(lastPoint);
-    futureUpper.unshift({ x: lastPoint.x, y: clamp(lastPoint.y + trend.moe, 0, 100) });
-    futureLower.unshift({ x: lastPoint.x, y: clamp(lastPoint.y - trend.moe, 0, 100) });
+    futureUpper.unshift({ x: lastPoint.x, y: lastPoint.y });
+    futureLower.unshift({ x: lastPoint.x, y: lastPoint.y });
   }
 
   const perCardStats = deck.map(d => {


### PR DESCRIPTION
## Summary
- Prepend last known progress to forecast datasets so trend lines connect seamlessly
- Extend forecast upper/lower bounds and progress bar prediction to start from current progress

## Testing
- `node --check app.js stats.js`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689818cbb18c8332b3842db129951a78