### PR TITLE
Remember account code locally and prompt to load

### DIFF
--- a/app.js
+++ b/app.js
@@ -61,6 +61,7 @@
         stats = data.stats;
       }
     }
+    localStorage.setItem('accountCode', accountCode);
   }
   const cardProgressChart = new Chart(document.getElementById('cardProgressChart').getContext('2d'), {
     type: 'line',

--- a/help.html
+++ b/help.html
@@ -18,6 +18,7 @@
     <p>ShawCards helps you learn the Shavian alphabet with flashcards and tracks your mastery as you practice.</p>
     <h2>Saving your progress</h2>
     <p>Your progress lives on our server. The code after the <code>#</code> in the URL is your account—bookmark or share the link to continue on any device.</p>
+    <p>We also remember this code in your browser and will offer to reload it if you return without it.</p>
     <h2>Using the flashcards</h2>
     <p>Flip the card with a click or the <kbd>↑</kbd> key. Mark answers with <kbd>←</kbd> for wrong and <kbd>→</kbd> for correct. Use <kbd>↓</kbd> to skip.</p>
     <h3>Progress bar</h3>

--- a/help.js
+++ b/help.js
@@ -8,6 +8,7 @@
     location.hash = accountCode;
     isNew = true;
   }
+  localStorage.setItem('accountCode', accountCode);
   document.querySelectorAll('a[href="/"], a[href="/stats"], a[href="/cheatsheet"], a[href="/help"]').forEach(link => {
     const path = link.getAttribute('href').split('#')[0];
     link.href = path + '#' + accountCode;

--- a/index.html
+++ b/index.html
@@ -8,7 +8,14 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
   <script>
-    if (!location.hash) location.replace('/help');
+    if (!location.hash) {
+      const saved = localStorage.getItem('accountCode');
+      if (saved && confirm('Load saved progress?')) {
+        location.hash = saved;
+      } else {
+        location.replace('/help');
+      }
+    }
   </script>
 </head>
   <body class="flashcard-page">


### PR DESCRIPTION
## Summary
- Preserve account codes in browser storage across the app and help pages.
- Prompt visitors to load saved progress when returning without a hash.
- Document new auto-reload workflow in help page.

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cfd7a86a48332be8076bfb65ad3c2