### PR TITLE
Add back button and arrow key cooldown

### DIFF
--- a/help.html
+++ b/help.html
@@ -20,7 +20,7 @@
     <p>Your progress lives on our server. The code after the <code>#</code> in the URL is your account—bookmark or share the link to continue on any device.</p>
     <p>We also remember this code in your browser and will offer to reload it if you return without it.</p>
     <h2>Using the flashcards</h2>
-    <p>Flip the card with a click or the <kbd>↑</kbd> key. Mark answers with <kbd>←</kbd> for wrong and <kbd>→</kbd> for correct. Use <kbd>↓</kbd> to skip.</p>
+    <p>Flip the card with a click or the <kbd>↑</kbd> key. Mark answers with <kbd>←</kbd> for wrong and <kbd>→</kbd> for correct. Use <kbd>↓</kbd> to skip. If you make a mistake, use the Back button to undo your last action. Arrow key controls have a brief delay to prevent accidental repeats.</p>
     <h3>Progress bar</h3>
     <p>The bar above the card shows how well you've learned it. The green portion is your current mastery. The translucent blue extension forecasts where you'll be after the next attempt.</p>
     <div class="progress"><div id="progressInner"></div><div id="forecastInner"></div></div>

--- a/index.html
+++ b/index.html
@@ -40,12 +40,13 @@
       <div class="chart-wrap"><canvas id="cardProgressChart"></canvas></div>
 
       <div class="controls card-controls">
+        <button id="backBtn">Back</button>
         <button id="skipBtn">Skip</button>
         <button id="wrongBtn" class="wrong">Wrong</button>
         <button id="correctBtn" class="correct">Correct</button>
       </div>
 
-      <p class="tip">Click or press <kbd>↑</kbd> to flip. Use <kbd>←</kbd>/<kbd>→</kbd> for Wrong/Correct, <kbd>↓</kbd> to skip.</p>
+      <p class="tip">Click or press <kbd>↑</kbd> to flip. Use <kbd>←</kbd>/<kbd>→</kbd> for Wrong/Correct, <kbd>↓</kbd> to skip. Use the Back button to undo the last action.</p>
     </section>
   </main>
   <script src="/app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -78,7 +78,7 @@ td.glyph{ font-size:22px; }
     border-top:1px solid var(--line);
     background:rgba(255,255,255,0.95);
     display:grid;
-    grid-template-columns:repeat(3,1fr);
+    grid-template-columns:repeat(4,1fr);
     padding:8px;
     gap:8px;
   }


### PR DESCRIPTION
## Summary
- add history stack and back button to undo the last card action
- throttle arrow key actions to prevent spamming
- document new workflow in help page and layout for mobile

## Testing
- `go test ./...` *(fails: command hung with no output)*

------
https://chatgpt.com/codex/tasks/task_e_689d4e3204b08332a62c9656c3312775