### PR TITLE
Add cross-platform build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ ShawCards is a small web application for practicing the Shavian alphabet with fl
 
 ## Building
 
-Use the provided script to build binaries for Linux, macOS, and Windows:
+Use the provided script to build binaries for Linux, macOS, and Windows on both `amd64` and `arm64` architectures:
 
 ```bash
 ./build.sh
 ```
 
-The compiled binaries are written to the `build` directory.
+The compiled binaries are written to the `build` directory as `shawcards_<os>_<arch>`.
 
 ## Available Pages
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ ShawCards is a small web application for practicing the Shavian alphabet with fl
    The application listens on [http://localhost:8080](http://localhost:8080).
 3. The first run creates a `data.db` SQLite database in the project directory to store progress.
 
+## Building
+
+Use the provided script to build binaries for Linux, macOS, and Windows:
+
+```bash
+./build.sh
+```
+
+The compiled binaries are written to the `build` directory.
+
 ## Available Pages
 
 - `/` – Flashcard practice interface

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+OUTPUT_DIR="build"
+mkdir -p "$OUTPUT_DIR"
+
+PLATFORMS=("linux" "darwin" "windows")
+ARCH="amd64"
+
+for GOOS in "${PLATFORMS[@]}"; do
+  echo "Building for $GOOS/$ARCH..."
+  EXT=""
+  if [ "$GOOS" = "windows" ]; then
+    EXT=".exe"
+  fi
+  env GOOS="$GOOS" GOARCH="$ARCH" CGO_ENABLED=0 go build -o "$OUTPUT_DIR/shawcards_${GOOS}_${ARCH}${EXT}" main.go
+done

--- a/build.sh
+++ b/build.sh
@@ -5,13 +5,15 @@ OUTPUT_DIR="build"
 mkdir -p "$OUTPUT_DIR"
 
 PLATFORMS=("linux" "darwin" "windows")
-ARCH="amd64"
+ARCHS=("amd64" "arm64")
 
 for GOOS in "${PLATFORMS[@]}"; do
-  echo "Building for $GOOS/$ARCH..."
-  EXT=""
-  if [ "$GOOS" = "windows" ]; then
-    EXT=".exe"
-  fi
-  env GOOS="$GOOS" GOARCH="$ARCH" CGO_ENABLED=0 go build -o "$OUTPUT_DIR/shawcards_${GOOS}_${ARCH}${EXT}" main.go
+  for GOARCH in "${ARCHS[@]}"; do
+    echo "Building for $GOOS/$GOARCH..."
+    EXT=""
+    if [ "$GOOS" = "windows" ]; then
+      EXT=".exe"
+    fi
+    env GOOS="$GOOS" GOARCH="$GOARCH" CGO_ENABLED=0 go build -o "$OUTPUT_DIR/shawcards_${GOOS}_${GOARCH}${EXT}" main.go
+  done
 done


### PR DESCRIPTION
## Summary
- add build.sh to compile binaries for Linux, macOS, and Windows
- document cross-platform building in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d593ad43c8332a9592ff05d0d2d7c